### PR TITLE
Convert fetched results to string

### DIFF
--- a/module/module.py
+++ b/module/module.py
@@ -126,7 +126,7 @@ class MySQL_importer_arbiter(BaseModule):
                     h = {}
                     for column in row:
                         if row[column]:
-                            h[column] = row[column]
+                            h[column] = str(row[column])
                     r[k].append(h)
 
         cursor.close()


### PR DESCRIPTION
Hi!

The module expects always string values. It's a problem if your database store integer fields (for example: check_interval should be an integer instead of an string).

```
[1410868111] Critical : I got an unrecoverable error. I have to exit
[1410868111] Critical : You can log a bug ticket at https://github.com/naparuba/shinken/issues/new to get help
[1410868111] Critical : Exception trace follows: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/shinken/daemons/arbiterdaemon.py", line 595, in main
    self.load_config_file()
  File "/usr/local/lib/python2.7/dist-packages/shinken/daemons/arbiterdaemon.py", line 349, in load_config_file
    self.conf.create_objects(raw_objects)
  File "/usr/local/lib/python2.7/dist-packages/shinken/objects/config.py", line 657, in create_objects
    self.create_objects_for_type(raw_objects, t)
  File "/usr/local/lib/python2.7/dist-packages/shinken/objects/config.py", line 676, in create_objects_for_type
    o = cls(obj_cfg)
  File "/usr/local/lib/python2.7/dist-packages/shinken/objects/item.py", line 96, in __init__
    len(params[key]) >= 1 and params[key][0] == '+':
TypeError: object of type 'long' has no len()
```

Please, apply this trivial patch to the module, or document the need to use only string fields in the source database.

Thanks in advance.
